### PR TITLE
Add version flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,11 @@ func newRootCommand() *cobra.Command {
 It supports listing existing keys, adding new keys, and retrieving passwords.`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		Version:       Version,
 	}
+
+	cmd.Flags().BoolP("version", "V", false, "version for restic-age-key")
+	cmd.SetVersionTemplate("{{.Version}}\n")
 
 	cmd.PersistentFlags().StringVar(&options.ageProgram, "age-program", options.ageProgram, "path to age binary")
 	cmd.PersistentFlags().StringVar(&options.rcloneProgram, "rclone-program", options.rcloneProgram, "path to rclone")

--- a/testdata/version-flag.txtar
+++ b/testdata/version-flag.txtar
@@ -1,0 +1,7 @@
+exec restic-age-key --version
+stdout '[0-9]+\.[0-9]+\.[0-9]+'
+! stderr .
+
+exec restic-age-key -V
+stdout '[0-9]+\.[0-9]+\.[0-9]+'
+! stderr .


### PR DESCRIPTION
## Summary
- support `--version` and `-V` flags
- add script test for version output

## Testing
- `go test -run 'Script/version-flag' -count=1`
- `go test ./...` *(fails: password-command-manual etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6865c239b3348326af28cae2eafdc5ea