### PR TITLE
Enable testscript updates via environment variable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ go test -cover ./...
 
 The test suite uses [testscript](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript). Test files live in the `testdata` directory and contain scripts that execute commands and compare their output. These tests differ from standard Go tests because they drive the program via shell-like scripts instead of calling functions directly.
 
+Set the environment variable `UPDATE_SCRIPTS=true` when running tests to enable automatic updates of testscript output files.
+
 ## Formatting
 
 Format code with:

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"strconv"
 	"testing"
 
 	"github.com/rogpeppe/go-internal/testscript"
@@ -13,9 +15,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestScript(t *testing.T) {
+	updateScripts, _ := strconv.ParseBool(os.Getenv("UPDATE_SCRIPTS"))
+
 	testscript.Run(t, testscript.Params{
 		Dir:             "testdata",
 		ContinueOnError: true,
-		// UpdateScripts:   true,
+		UpdateScripts:   updateScripts,
 	})
 }


### PR DESCRIPTION
## Summary
- allow the testscript suite to enable UpdateScripts when UPDATE_SCRIPTS parses to true
- document the UPDATE_SCRIPTS test helper in AGENTS.md

## Testing
- go test ./... *(fails: missing `restic` executable required by the test scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb5a6be9083268a60c7083c4cc1b8