### PR TITLE
Use ubuntu-slim for merge workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     if: github.actor == 'dependabot[bot]' && github.repository == 'josh/restic-age-key'
 
     steps:


### PR DESCRIPTION
## Summary
- switch the merge workflow job to run on the ubuntu-slim container runner

## Testing
- not run (not necessary for workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692376826a6c8326bee00f75c840f31a)