### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
## Summary
- add a 14-day cooldown to dependabot configuration for GitHub Actions and Go modules updates

## Testing
- not run (not required)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e6a9ddedc8326a5537b907c5116a4)