### PR TITLE
repo-init: validate recipients before creating repository

### DIFF
--- a/main.go
+++ b/main.go
@@ -534,6 +534,44 @@ func runRepoInit(ctx context.Context, opts options, args []string) error {
 		return fmt.Errorf("failed to get chunker polynomial: %w", err)
 	}
 
+	var recipients []Recipient
+	if opts.recipientsFile != "" {
+		recipients, err = readRecipientsFile(opts.recipientsFile)
+		if err != nil {
+			return fmt.Errorf("failed to read recipients file: %w", err)
+		}
+
+		if len(recipients) == 0 {
+			return errors.New("Fatal: Recipients file contains no recipients") //nolint:staticcheck
+		}
+	}
+
+	preflight := recipients
+	if opts.recipientsFile == "" {
+		preflight = []Recipient{{Pubkey: opts.recipient}}
+	}
+	for _, recipient := range preflight {
+		host := recipient.Host
+		if host == "" {
+			host = opts.host
+		}
+		if host == "" {
+			return errors.New("hostname is empty")
+		}
+
+		user := recipient.User
+		if user == "" {
+			user = opts.user
+		}
+		if user == "" {
+			return errors.New("username is empty")
+		}
+
+		if _, _, err := ageEncryptRandomKey(ctx, opts.ageProgram, recipient.Pubkey); err != nil {
+			return fmt.Errorf("invalid age recipient %s: %w", recipient.Pubkey, err)
+		}
+	}
+
 	var tempPasswordBuf [32]byte
 	if _, err := rand.Read(tempPasswordBuf[:]); err != nil {
 		return fmt.Errorf("failed to generate temporary password: %w", err)
@@ -552,15 +590,6 @@ func runRepoInit(ctx context.Context, opts options, args []string) error {
 	var ageKeyIDs []restic.ID
 
 	if opts.recipientsFile != "" {
-		recipients, err := readRecipientsFile(opts.recipientsFile)
-		if err != nil {
-			return fmt.Errorf("failed to read recipients file: %w", err)
-		}
-
-		if len(recipients) == 0 {
-			return errors.New("Fatal: Recipients file contains no recipients") //nolint:staticcheck
-		}
-
 		for _, recipient := range recipients {
 			host := recipient.Host
 			if host == "" {
@@ -607,7 +636,6 @@ func runRepoInit(ctx context.Context, opts options, args []string) error {
 	fmt.Fprintln(os.Stderr, "repository version: 2")
 
 	if opts.recipientsFile != "" {
-		recipients, _ := readRecipientsFile(opts.recipientsFile)
 		for i, ageKeyID := range ageKeyIDs {
 			host := recipients[i].Host
 			if host == "" {

--- a/testdata/repo-init-bad-recipient.txtar
+++ b/testdata/repo-init-bad-recipient.txtar
@@ -1,0 +1,7 @@
+env RESTIC_AGE_USER=alice
+env RESTIC_AGE_HOST=localhost
+
+! exec restic-age-key repo-init --repo $WORK/repo --recipient not-an-age-key
+! stdout .
+stderr 'invalid age recipient not-an-age-key'
+! exists $WORK/repo/config


### PR DESCRIPTION
The recipients file was read twice: once to create keys and again to print the summary, where the error was ignored and recipients[i] could panic on a nil or shortened slice if the file changed or became unreadable between reads. Read it once up front and reuse the result.

Also probe each recipient with age and check for an empty host or user before repository.Init runs. Previously a bad recipient or missing age binary failed after the repository was created, leaving behind a repo whose only key is a random temporary password nobody knows, and a rerun fails on the existing config with no recovery path short of wiping the backend.