### PR TITLE
readPassword: report password file read errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -1029,7 +1029,7 @@ func readPassword(ctx context.Context, opts *options) (string, error) {
 		return opts.password, nil
 	} else if opts.passwordFile != "" {
 		s, err := textfile.Read(opts.passwordFile)
-		if errors.Is(err, os.ErrNotExist) {
+		if err != nil {
 			return "", fmt.Errorf("failed to read password file: %w", err)
 		}
 

--- a/testdata/add-unreadable-password-file.txtar
+++ b/testdata/add-unreadable-password-file.txtar
@@ -1,0 +1,14 @@
+env RESTIC_REPOSITORY=$WORK/repo
+exec restic init --password-file $WORK/password.txt
+
+exec cp $WORK/password.txt $WORK/secret-password.txt
+exec chmod 000 $WORK/secret-password.txt
+
+! exec restic-age-key add --password-file $WORK/secret-password.txt --recipient age1tmkxjxzan25j6rmjpuffq2ft8z45q75knm356qaypcczvsz4pvds46d9l7
+! stdout .
+stderr 'Resolving password failed'
+stderr 'permission denied'
+! stderr 'empty password file'
+
+-- password.txt --
+secret


### PR DESCRIPTION
Only os.ErrNotExist was propagated from textfile.Read; any other failure (permission denied, invalid UTF-16 after a BOM) was dropped, leaving an empty buffer that got misreported as "empty password file". Propagate every read error with its real cause.