### PR TITLE
repo-init: reject chunker polynomials restic cannot use

### DIFF
--- a/main.go
+++ b/main.go
@@ -652,6 +652,9 @@ func parseChunkerPolynomial(hexStr string) (*chunker.Pol, error) {
 	}
 
 	pol := chunker.Pol(val)
+	if pol.Deg() != 53 || !pol.Irreducible() {
+		return nil, fmt.Errorf("invalid chunker polynomial: %s is not an irreducible polynomial of degree 53", hexStr)
+	}
 	return &pol, nil
 }
 

--- a/testdata/repo-init-reducible-polynomial.txtar
+++ b/testdata/repo-init-reducible-polynomial.txtar
@@ -1,0 +1,10 @@
+env RESTIC_AGE_USER=alice
+env RESTIC_AGE_HOST=localhost
+
+! exec restic-age-key repo-init --repo $WORK/repo --recipient age1tmkxjxzan25j6rmjpuffq2ft8z45q75knm356qaypcczvsz4pvds46d9l7 --chunker-polynomial 0x4 --identity-file $WORK/key.txt
+! stdout .
+stderr 'invalid chunker polynomial'
+! exists $WORK/repo/config
+
+-- key.txt --
+AGE-SECRET-KEY-1QFNZQKV0TAXNDEXVR3MCZPANFJ0PNYXPEVNSTXSRQ9GM3KTHS5QW3DNKH


### PR DESCRIPTION
parseChunkerPolynomial only checked that the value parsed as an integer. repository.Init writes the polynomial to the repo config verbatim, but restic validates Irreducible() on every subsequent open, so a reducible value (e.g. 0x4) produced a repository that reports "created restic repository" and is then permanently unopenable by both restic and restic-age-key. Validate degree 53 and irreducibility up front, matching what restic generates and the chunker requires.