### PR TITLE
password: keep trying keys after a decrypt error

### DIFF
--- a/main.go
+++ b/main.go
@@ -874,6 +874,7 @@ func readPasswordViaIdentity(ctx context.Context, opts options) (string, error) 
 	}
 
 	var password string
+	var keyErr error
 
 	err = repo.List(ctx, restic.KeyFile, func(id restic.ID, size int64) error {
 		if password != "" {
@@ -882,6 +883,10 @@ func readPasswordViaIdentity(ctx context.Context, opts options) (string, error) 
 
 		data, err := repo.LoadRaw(ctx, restic.KeyFile, id)
 		if err != nil {
+			if keyErr == nil {
+				keyErr = err
+			}
+
 			return nil
 		}
 
@@ -896,25 +901,35 @@ func readPasswordViaIdentity(ctx context.Context, opts options) (string, error) 
 			return nil
 		}
 
-		password, err = ageDecryptKey(ctx, opts.ageProgram, opts.identityFile, k.AgeData)
+		pw, err := ageDecryptKey(ctx, opts.ageProgram, opts.identityFile, k.AgeData)
 		if err != nil {
 			if strings.Contains(err.Error(), "no identity matched any of the recipients") {
 				return nil
 			}
 
-			return err
+			if keyErr == nil {
+				keyErr = err
+			}
+
+			return nil
 		}
+
+		password = pw
 
 		return nil
 	})
 
 	if password != "" {
 		return password, nil
-	} else if err != nil {
-		return "", err
-	} else {
-		return "", errors.New("no password found")
 	}
+	if keyErr != nil {
+		return "", keyErr
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return "", errors.New("no password found")
 }
 
 func ageEncryptRandomKey(ctx context.Context, ageProgram string, pubkey string) (string, []byte, error) {

--- a/testdata/password-corrupt-age-key.txtar
+++ b/testdata/password-corrupt-age-key.txtar
@@ -1,0 +1,29 @@
+env RESTIC_REPOSITORY=$WORK/repo
+exec restic init --password-file password.txt
+
+exec restic-age-key add --password-file password.txt --recipient age1tmkxjxzan25j6rmjpuffq2ft8z45q75knm356qaypcczvsz4pvds46d9l7
+
+exec bash corrupt-age-keys.bash
+
+exec restic-age-key add --password-file password.txt --recipient age1tmkxjxzan25j6rmjpuffq2ft8z45q75knm356qaypcczvsz4pvds46d9l7
+
+exec restic-age-key password --identity-file key.txt
+stdout [a-f0-9]{64}
+! stderr .
+
+-- corrupt-age-keys.bash --
+set -e
+for f in repo/keys/*; do
+  if jq -e '."age-pubkey"' "$f" >/dev/null; then
+    jq -c '."age-data" = "bm90IGFuIGFnZSBmaWxl"' "$f" > "$f.tmp"
+    id=$(sha256sum "$f.tmp" | cut -d' ' -f1)
+    mv "$f.tmp" "repo/keys/$id"
+    rm "$f"
+  fi
+done
+
+-- password.txt --
+secret
+
+-- key.txt --
+AGE-SECRET-KEY-16HXZ3F6C8JSN9NDFCD8XLGHKS7L39M5PVCS3A53DXX5WT9SPV65Q08EAAY


### PR DESCRIPTION
A key whose age-data failed to decrypt for any reason other than "no identity matched" aborted the whole key listing, so one corrupted age key could block password recovery even when another key matched the identity. Backend read errors for individual key files were silently skipped and surfaced as "no password found".

Remember the first real error, keep trying the remaining keys, and only report the error when no key yields a password.