### PR TITLE
set: remove every key file sharing a stale pubkey

### DIFF
--- a/main.go
+++ b/main.go
@@ -733,7 +733,7 @@ func runKeySet(ctx context.Context, opts options, args []string) error {
 		return err
 	}
 
-	repoKeys := make(map[string]Recipient)
+	repoKeys := make(map[string][]Recipient)
 
 	err = repo.List(ctx, restic.KeyFile, func(id restic.ID, size int64) error {
 		data, err := repo.LoadRaw(ctx, restic.KeyFile, id)
@@ -753,12 +753,12 @@ func runKeySet(ctx context.Context, opts options, args []string) error {
 		}
 
 		if k.AgePubkey != "" {
-			repoKeys[k.AgePubkey] = Recipient{
+			repoKeys[k.AgePubkey] = append(repoKeys[k.AgePubkey], Recipient{
 				ID:     id,
 				Pubkey: k.AgePubkey,
 				Host:   k.Hostname,
 				User:   k.Username,
-			}
+			})
 		}
 
 		return nil
@@ -776,7 +776,7 @@ func runKeySet(ctx context.Context, opts options, args []string) error {
 		}
 	}
 
-	for pubkey, existingRecipient := range repoKeys {
+	for pubkey, existingRecipients := range repoKeys {
 		found := false
 		for _, recipient := range setRecipients {
 			if pubkey == recipient.Pubkey {
@@ -785,7 +785,7 @@ func runKeySet(ctx context.Context, opts options, args []string) error {
 			}
 		}
 		if !found {
-			keysToRemove = append(keysToRemove, existingRecipient)
+			keysToRemove = append(keysToRemove, existingRecipients...)
 		}
 	}
 

--- a/testdata/set-remove-duplicate-keys.txtar
+++ b/testdata/set-remove-duplicate-keys.txtar
@@ -1,0 +1,30 @@
+env RESTIC_REPOSITORY=$WORK/repo
+env RESTIC_PASSWORD_FILE=$WORK/password.txt
+
+exec restic init
+
+exec restic-age-key add --recipient=age1th5qzv24ehstkdzljusxwcr4m2rfq4xvd662ppent47x4lqzgatsp7hvts
+exec restic-age-key add --recipient=age1th5qzv24ehstkdzljusxwcr4m2rfq4xvd662ppent47x4lqzgatsp7hvts
+
+exec bash restic-key-count.bash
+stdout 3
+
+exec restic-age-key set --recipients-file=recipients.json
+
+exec restic-age-key list
+stdout 'age1g5wluv38nl0vj6p3f7slgq6x4fxexwaqpqt3nctgs9n8jqf6g9wq5ywxfw'
+! stdout 'age1th5qzv24ehstkdzljusxwcr4m2rfq4xvd662ppent47x4lqzgatsp7hvts'
+
+exec bash restic-key-count.bash
+stdout 2
+
+-- restic-key-count.bash --
+restic key list --no-cache --json | jq length
+
+-- password.txt --
+secret
+
+-- recipients.json --
+[
+    { "host": "alice.local", "user": "alice", "pubkey": "age1g5wluv38nl0vj6p3f7slgq6x4fxexwaqpqt3nctgs9n8jqf6g9wq5ywxfw" }
+]


### PR DESCRIPTION
Repository keys were collected into a map keyed by pubkey, so when the same recipient had been added more than once only the last-listed key file was tracked. A set run then removed just one duplicate per run, in backend list order, while claiming the repository had converged on the recipients file. Track all key files per pubkey and remove them all.