### PR TITLE
age: fall back to exec error when stderr is empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -964,7 +964,7 @@ func ageEncryptRandomKey(ctx context.Context, ageProgram string, pubkey string) 
 		}
 
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
 			return "", nil, fmt.Errorf("%s", string(exitErr.Stderr))
 		}
 
@@ -985,7 +985,7 @@ func ageDecryptKey(ctx context.Context, ageProgram string, identityFile string, 
 		}
 
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
 			return "", fmt.Errorf("%s", string(exitErr.Stderr))
 		}
 

--- a/testdata/add-age-silent-failure.txtar
+++ b/testdata/add-age-silent-failure.txtar
@@ -1,0 +1,19 @@
+env RESTIC_REPOSITORY=$WORK/repo
+env RESTIC_PASSWORD_FILE=$WORK/password.txt
+env RESTIC_AGE_USER=alice
+env RESTIC_AGE_HOST=localhost
+
+exec chmod +x fake-age
+
+exec restic init
+
+! exec restic-age-key add --age-program $WORK/fake-age --recipient age1tmkxjxzan25j6rmjpuffq2ft8z45q75knm356qaypcczvsz4pvds46d9l7
+! stdout .
+stderr 'failed to encrypt key with age: exit status 1'
+
+-- password.txt --
+secret
+
+-- fake-age --
+#!/bin/sh
+exit 1


### PR DESCRIPTION
Errors from the age subprocess were reported as the raw stderr text. When age is killed by a signal or exits without writing anything, the resulting error message was an empty string and the command exited 1 printing only a blank line. Use the wrapped exec error instead when there is no stderr output.