### PR TITLE
add: require repository location like other commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -451,6 +451,10 @@ func buildAndSaveAgeKey(ctx context.Context, ageProgram, recipient, host, user s
 }
 
 func runKeyAdd(ctx context.Context, opts options, args []string) error {
+	if opts.repo == "" {
+		return errors.New("Fatal: Please specify repository location (-r or --repository-file)") //nolint:staticcheck
+	}
+
 	repo, be, err := openRepositoryWithPassword(ctx, opts)
 	if err != nil {
 		return err

--- a/testdata/add-missing-repo.txtar
+++ b/testdata/add-missing-repo.txtar
@@ -1,0 +1,12 @@
+! exec restic key add
+! stdout .
+cmp stderr restic-stderr.txt
+
+! exec restic-age-key add --recipient age1tmkxjxzan25j6rmjpuffq2ft8z45q75knm356qaypcczvsz4pvds46d9l7
+! stdout .
+cmp stderr restic-age-key-stderr.txt
+
+-- restic-stderr.txt --
+Fatal: Please specify repository location (-r or --repository-file)
+-- restic-age-key-stderr.txt --
+Fatal: Please specify repository location (-r or --repository-file)


### PR DESCRIPTION
list, set, password, and repo-init all reject a missing repository location up front; add fell through to location.Parse("") and failed later with a misleading "repository does not exist" error. Use the same fatal message restic prints.