### PR TITLE
set: include cause when recipients file is unreadable

### DIFF
--- a/main.go
+++ b/main.go
@@ -756,7 +756,7 @@ func runKeySet(ctx context.Context, opts options, args []string) error {
 
 	setRecipients, err := readRecipientsFile(opts.recipientsFile)
 	if err != nil {
-		return errors.New("Fatal: Unable to read recipients file") //nolint:staticcheck
+		return fmt.Errorf("Fatal: Unable to read recipients file: %w", err) //nolint:staticcheck
 	}
 
 	repo, be, err := openRepositoryWithPassword(ctx, opts)

--- a/testdata/set-missing-recipients-file.txtar
+++ b/testdata/set-missing-recipients-file.txtar
@@ -4,10 +4,10 @@ env RESTIC_PASSWORD_FILE=$WORK/password.txt
 exec restic init
 
 ! exec restic-age-key set --recipients-file=$WORK/non-existent-file.json
-cmp stderr set-stderr.txt
+cmpenv stderr set-stderr.txt
 
 -- password.txt --
 secret
 
 -- set-stderr.txt --
-Fatal: Unable to read recipients file
+Fatal: Unable to read recipients file: open $WORK/non-existent-file.json: no such file or directory


### PR DESCRIPTION
The fixed "Fatal: Unable to read recipients file" string hid whether the file was missing, unreadable, or contained invalid JSON. Wrap the underlying error like repo-init does.