### PR TITLE
openRepository: report config stat errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -1169,6 +1169,9 @@ func openRepository(ctx context.Context, opts options) (*repository.Repository, 
 	if be.IsNotExist(err) {
 		return nil, nil, errors.New("repository does not exist: unable to open config file")
 	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to open config file: %w", err)
+	}
 
 	return r, be, nil
 }

--- a/testdata/list-unreadable-repo.txtar
+++ b/testdata/list-unreadable-repo.txtar
@@ -1,0 +1,16 @@
+env RESTIC_REPOSITORY=$WORK/repo
+env RESTIC_PASSWORD_FILE=$WORK/password.txt
+
+exec restic init
+
+exec chmod 000 $WORK/repo
+
+! exec restic-age-key list
+! stdout .
+stderr 'unable to open config file'
+stderr 'permission denied'
+
+exec chmod 755 $WORK/repo
+
+-- password.txt --
+secret


### PR DESCRIPTION
Only not-exist results from the backend Stat of the config file were handled; any other failure (permission denied, auth or network errors) was dropped and surfaced later as an unrelated message such as "no password found". Report the stat error directly.