### PR TITLE
check close errors when writing output files

### DIFF
--- a/main.go
+++ b/main.go
@@ -477,10 +477,14 @@ func runKeyAdd(ctx context.Context, opts options, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to write key id to file: %w", err)
 		}
-		defer func() { _ = file.Close() }()
 
 		_, err = file.WriteString(id.String()[0:8] + "\n")
 		if err != nil {
+			_ = file.Close()
+			return fmt.Errorf("failed to write key id to file: %w", err)
+		}
+
+		if err := file.Close(); err != nil {
 			return fmt.Errorf("failed to write key id to file: %w", err)
 		}
 	}
@@ -504,9 +508,12 @@ func runKeyPassword(ctx context.Context, opts options, args []string) error {
 			return fmt.Errorf("failed to write password to file: %w", err)
 		}
 
-		defer func() { _ = file.Close() }()
-
 		if _, err := file.WriteString(password + "\n"); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("failed to write password to file: %w", err)
+		}
+
+		if err := file.Close(); err != nil {
 			return fmt.Errorf("failed to write password to file: %w", err)
 		}
 	} else {
@@ -656,13 +663,17 @@ func runRepoInit(ctx context.Context, opts options, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create output file: %w", err)
 		}
-		defer func() { _ = file.Close() }()
 
 		for _, ageKeyID := range ageKeyIDs {
 			_, err = file.WriteString(ageKeyID.Str()[0:8] + "\n")
 			if err != nil {
+				_ = file.Close()
 				return fmt.Errorf("failed to write to output file: %w", err)
 			}
+		}
+
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("failed to write to output file: %w", err)
 		}
 	}
 


### PR DESCRIPTION
The --output files for add, password, and repo-init were closed via a defer that discarded the error, so a write that fails at close time (NFS deferred flush, full disk) still exited 0 and left a truncated or empty file for scripts to consume. Report close failures.