### PR TITLE
Handle whitespace-only command values without panicking

### DIFF
--- a/main.go
+++ b/main.go
@@ -1041,10 +1041,16 @@ func readIdentityCommand(ctx context.Context, opts *options) (func(), error) {
 
 		return noop, nil
 	}
+	if strings.TrimSpace(opts.identityCommand) == "" {
+		return noop, errors.New("identity command is empty")
+	}
 
 	args, err := backend.SplitShellStrings(opts.identityCommand)
 	if err != nil {
 		return noop, fmt.Errorf("failed to split shell string: %w", err)
+	}
+	if len(args) == 0 {
+		return noop, errors.New("identity command is empty")
 	}
 
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
@@ -1105,9 +1111,16 @@ func readPassword(ctx context.Context, opts *options) (string, error) {
 
 		return password, nil
 	} else if opts.passwordCommand != "" {
+		if strings.TrimSpace(opts.passwordCommand) == "" {
+			return "", errors.New("password command is empty")
+		}
+
 		args, err := backend.SplitShellStrings(opts.passwordCommand)
 		if err != nil {
 			return "", err
+		}
+		if len(args) == 0 {
+			return "", errors.New("password command is empty")
 		}
 
 		cmd := exec.CommandContext(ctx, args[0], args[1:]...)

--- a/testdata/empty-command-values.txtar
+++ b/testdata/empty-command-values.txtar
@@ -1,0 +1,41 @@
+env RESTIC_REPOSITORY=$WORK/repo
+exec restic init --password-file $WORK/password.txt
+
+# A whitespace-only identity command passed as a flag returns an error, not a panic.
+! exec restic-age-key password --identity-command '   '
+! stdout .
+! stderr 'panic:'
+! stderr '^goroutine [0-9]+'
+cmp stderr identity-stderr.txt
+
+# A whitespace-only identity command from the environment behaves the same way.
+env RESTIC_AGE_IDENTITY_COMMAND='   '
+! exec restic-age-key password
+! stdout .
+! stderr 'panic:'
+! stderr '^goroutine [0-9]+'
+cmp stderr identity-stderr.txt
+env RESTIC_AGE_IDENTITY_COMMAND=
+
+# A whitespace-only password command passed as a flag returns an error, not a panic.
+! exec restic-age-key add --password-command '   '
+! stdout .
+! stderr 'panic:'
+! stderr '^goroutine [0-9]+'
+cmp stderr password-stderr.txt
+
+# A whitespace-only password command from the environment behaves the same way.
+env RESTIC_PASSWORD_COMMAND='   '
+! exec restic-age-key add
+! stdout .
+! stderr 'panic:'
+! stderr '^goroutine [0-9]+'
+cmp stderr password-stderr.txt
+
+-- password.txt --
+secret
+
+-- identity-stderr.txt --
+Resolving identity failed: identity command is empty
+-- password-stderr.txt --
+Fatal: Resolving password failed: password command is empty


### PR DESCRIPTION
### Motivation

- Prevent indexing into an empty `args` slice when `backend.SplitShellStrings` returns an empty list for `identity` or `password` command options. 
- Ensure calling code receives a clear, stable validation error instead of causing a panic or emitting a Go stack trace when users pass whitespace-only flag values or environment variables.

### Description

- Add a check immediately after `backend.SplitShellStrings` in `readIdentityCommand` that returns `identity command is empty` when `len(args) == 0` instead of indexing `args[0]`. 
- Add an equivalent check in the password-command branch of `readPassword` that returns `password command is empty` when `len(args) == 0` before attempting to execute the command. 
- Add a testscript file `testdata/empty-command-values.txtar` that exercises both commands with whitespace-only flag values and environment-variable values and asserts a failing exit with exact stderr messages and no panic/stack trace.

### Testing

- Ran the test suite with `go test ./...`, which exercised the `testscript` regression cases in `testdata/empty-command-values.txtar`, and it passed. 
- Ran static checks with `go vet ./...` and a build with `go build ./...`, both of which succeeded. 
- Ran formatting with `gofmt -w main.go` and verified the new `testdata` testscript asserts the stable stderr messages and absence of a Go panic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e1da360b083269f3d21aae96ad73a)